### PR TITLE
fix caffe time command.

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -162,6 +162,8 @@ class Caffe {
   static void EnumerateDevices();
   // Prepares contexts for devices to use
   static void SetDevices(std::vector<int> device_ids);
+  // Finish executing gpu kernels on the specified-device.
+  static void Synchronize(int device_id);
 
   // Get a device context
   static DeviceContext& GetDeviceContext(int id);

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -150,6 +150,19 @@ void Caffe::set_random_seed(const unsigned int seed) {
   Get().random_generator_.reset(new RNG(seed));
 }
 
+void Caffe::Synchronize(int device_id) {
+#ifdef USE_GREENTEA
+  DeviceContext& device_context = Caffe::GetDeviceContext(device_id);
+  if ( device_context.backend() == BACKEND_OpenCL ) {
+    viennacl::ocl::context &ctx = viennacl::ocl::get_context(
+                      GetDeviceContext(device_id).id());
+    ctx.get_queue().finish();
+  }
+#else
+  (void) device_id;
+#endif
+}
+
 void Caffe::EnumerateDevices() {
   int cuda_device_count = 0;
   int greentea_device_count = 0;

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -253,6 +253,7 @@ int time() {
     for (int i = 0; i < layers.size(); ++i) {
       timer.Start();
       layers[i]->Forward(bottom_vecs[i], top_vecs[i]);
+      Caffe::Synchronize(FLAGS_gpu);
       forward_time_per_layer[i] += timer.MicroSeconds();
     }
     forward_time += forward_timer.MicroSeconds();
@@ -261,6 +262,7 @@ int time() {
       timer.Start();
       layers[i]->Backward(top_vecs[i], bottom_need_backward[i],
                           bottom_vecs[i]);
+      Caffe::Synchronize(FLAGS_gpu);
       backward_time_per_layer[i] += timer.MicroSeconds();
     }
     backward_time += backward_timer.MicroSeconds();


### PR DESCRIPTION
When running the caffe time command, force kernels to finish executing before measuring the elapsed time. 

Before making this change, I was seeing incorrect per-layer benchmark times.

An easy way to see is to run: 
`build/tools/caffe time -model models/bvlc_alexnet/deploy.prototxt -gpu=0`

Without this change, one sees times such as this:

```
I0618 03:19:15.426265 17120 caffe.cpp:273]      conv5   forward: 2.62356 ms.
I0618 03:19:15.426286 17120 caffe.cpp:276]      conv5   backward: 16.4404 ms.
I0618 03:19:15.426303 17120 caffe.cpp:273]      relu5   forward: 18.7961 ms.
I0618 03:19:15.426319 17120 caffe.cpp:276]      relu5   backward: 0.00024 ms.
```

No way that relu takes longer than convolution layer. And the forward and backward for a given layer should be close to the same.

After this change, I see:

```
I0618 07:13:19.637118 23689 caffe.cpp:275]      conv5   forward: 21.761 ms.
I0618 07:13:19.637135 23689 caffe.cpp:278]      conv5   backward: 27.8604 ms.
I0618 07:13:19.637151 23689 caffe.cpp:275]      relu5   forward: 0.13252 ms.
I0618 07:13:19.637167 23689 caffe.cpp:278]      relu5   backward: 0.01498 ms.
```

Which is much more sensible.
