### PR TITLE
Enumerate devices

### DIFF
--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -71,7 +71,7 @@ static BrewFunction GetBrewFunction(const caffe::string& name) {
 // enumerate all devices if none is specified.
 int device_query() {
   if ( FLAGS_gpu < 0 ) {
-    //CHECK_GT(FLAGS_gpu, -1) << "Need a device ID to query.";
+    // If no gpu is specified, enumerate all the devices.
     Caffe::EnumerateDevices();
   } else {
     LOG(INFO) << "Querying device ID = " << FLAGS_gpu;

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -67,12 +67,17 @@ static BrewFunction GetBrewFunction(const caffe::string& name) {
 // To add a command, define a function "int command()" and register it with
 // RegisterBrewFunction(action);
 
-// Device Query: show diagnostic information for a GPU device.
+// Device Query: show diagnostic information for a GPU device, or
+// enumerate all devices if none is specified.
 int device_query() {
-  CHECK_GT(FLAGS_gpu, -1) << "Need a device ID to query.";
-  LOG(INFO) << "Querying device ID = " << FLAGS_gpu;
-  caffe::Caffe::SetDevice(FLAGS_gpu);
-  caffe::Caffe::DeviceQuery();
+  if ( FLAGS_gpu < 0 ) {
+    //CHECK_GT(FLAGS_gpu, -1) << "Need a device ID to query.";
+    Caffe::EnumerateDevices();
+  } else {
+    LOG(INFO) << "Querying device ID = " << FLAGS_gpu;
+    caffe::Caffe::SetDevice(FLAGS_gpu);
+    caffe::Caffe::DeviceQuery();
+  }
   return 0;
 }
 RegisterBrewFunction(device_query);


### PR DESCRIPTION
This change lets us run `caffe device_query` to see a list of all the devices.

e.g. 

```
$ build/tools/caffe device_query
I0618 10:58:53.997761 28934 common.cpp:193] Total devices: 3
I0618 10:58:53.997997 28934 common.cpp:198] OpenCL devices: 3
I0618 10:58:53.998009 28934 common.cpp:217] Device id:                     0
I0618 10:58:53.998023 28934 common.cpp:218] Device backend:                OpenCL
I0618 10:58:53.998044 28934 common.cpp:219] Backend details:               Advanced Micro Devices, Inc.: OpenCL 2.0 AMD-APP (1642.5)
I0618 10:58:53.998061 28934 common.cpp:220] Device vendor:                 Advanced Micro Devices, Inc.
I0618 10:58:53.998075 28934 common.cpp:221] Name:                          Tahiti
I0618 10:58:53.998088 28934 common.cpp:222] Total global memory:           2674917376
I0618 10:58:53.998102 28934 common.cpp:217] Device id:                     1
I0618 10:58:53.998114 28934 common.cpp:218] Device backend:                OpenCL
I0618 10:58:53.998128 28934 common.cpp:219] Backend details:               Advanced Micro Devices, Inc.: OpenCL 2.0 AMD-APP (1642.5)
I0618 10:58:53.998142 28934 common.cpp:220] Device vendor:                 Advanced Micro Devices, Inc.
I0618 10:58:53.998155 28934 common.cpp:221] Name:                          Hawaii
I0618 10:58:53.998167 28934 common.cpp:222] Total global memory:           4250927104
I0618 10:58:53.998178 28934 common.cpp:217] Device id:                     2
I0618 10:58:53.998191 28934 common.cpp:218] Device backend:                OpenCL
I0618 10:58:53.998205 28934 common.cpp:219] Backend details:               Advanced Micro Devices, Inc.: OpenCL 2.0 AMD-APP (1642.5)
I0618 10:58:53.998219 28934 common.cpp:220] Device vendor:                 AuthenticAMD
I0618 10:58:53.998231 28934 common.cpp:221] Name:                          AMD FX(tm)-6300 Six-Core Processor
I0618 10:58:53.998245 28934 common.cpp:222] Total global memory:           16771870720
```
