### PR TITLE
Fix OpenCL inclusion on OSX

### DIFF
--- a/include/caffe/greentea/greentea.hpp
+++ b/include/caffe/greentea/greentea.hpp
@@ -24,7 +24,12 @@
 #define VIENNACL_WITH_OPENCL
 #endif
 
+#ifndef __APPLE__
 #include "CL/cl.h"
+#else
+#include "OpenCL/cl.h"
+#endif
+
 #include "viennacl/backend/opencl.hpp"
 #include "viennacl/ocl/backend.hpp"
 #include "viennacl/ocl/context.hpp"


### PR DESCRIPTION
- When linking OpenCL from an OSX framework, the include
  path needs to be 'OpenCL/cl.h', rather than the more
  common 'CL/cl.h' found on linux platforms.
