### PR TITLE
Fixes required for OSX + clang 3.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ include(cmake/Dependencies.cmake)
 
 # ---[ Flags
 if(UNIX OR APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -std=c++11 -fopenmp -DCMAKE_BUILD")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -std=c++11 -DCMAKE_BUILD")
 endif()
 
 if(USE_libstdcpp)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++ -std=c++11 -fopenmp")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++ -std=c++11")
   message("-- Warning: forcing libstdc++ (controlled by USE_libstdcpp option in cmake)")
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -85,6 +85,11 @@ include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
 list(APPEND Caffe_LINKER_LIBS ${OpenCV_LIBS})
 message(STATUS "OpenCV found (${OpenCV_CONFIG_PATH})")
 
+# ---[ OpenMP
+find_package(OpenMP QUIET)
+# If OpenMP is not found then OpenMP_CXX_FLAGS will be empty
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+
 # ---[ BLAS
 if(NOT APPLE)
   set(BLAS "Atlas" CACHE STRING "Selected BLAS library")

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -46,6 +46,10 @@ private:\
   template class classname<float>; \
   template class classname<double>
 
+#if defined(USE_GREENTEA) && !defined(USE_CUDA)
+  #define INSTANTIATE_LAYER_GPU_FORWARD(classname)
+  #define INSTANTIATE_LAYER_GPU_BACKWARD(classname)
+#else
 #define INSTANTIATE_LAYER_GPU_FORWARD(classname) \
   template void classname<float>::Forward_gpu( \
       const std::vector<Blob<float>*>& bottom, \
@@ -63,6 +67,7 @@ private:\
       const std::vector<Blob<double>*>& top, \
       const std::vector<bool>& propagate_down, \
       const std::vector<Blob<double>*>& bottom)
+#endif
 
 #define INSTANTIATE_LAYER_GPU_FUNCS(classname) \
   INSTANTIATE_LAYER_GPU_FORWARD(classname); \

--- a/src/caffe/layers/absval_layer.cpp
+++ b/src/caffe/layers/absval_layer.cpp
@@ -1,13 +1,12 @@
-#if defined(USE_GREENTEA) && !defined(USE_CUDA)
-#include "absval_layer.cu"
-#endif
-
 #include <vector>
 
 #include "caffe/layer.hpp"
 #include "caffe/neuron_layers.hpp"
 #include "caffe/util/math_functions.hpp"
 
+#if defined(USE_GREENTEA) && !defined(USE_CUDA)
+#include "absval_layer.cu"
+#endif
 
 namespace caffe {
 

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -1,12 +1,12 @@
 #include <string>
 #include <vector>
 
+#include "caffe/data_layers.hpp"
+#include "caffe/util/io.hpp"
+
 #if defined(USE_GREENTEA) && !defined(USE_CUDA)
 #include "base_data_layer.cu"
 #endif
-
-#include "caffe/data_layers.hpp"
-#include "caffe/util/io.hpp"
 
 namespace caffe {
 

--- a/src/caffe/layers/bnll_layer.cpp
+++ b/src/caffe/layers/bnll_layer.cpp
@@ -1,12 +1,12 @@
 #include <algorithm>
 #include <vector>
 
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+
 #if defined(USE_GREENTEA) && !defined(USE_CUDA)
 #include "bnll_layer.cu"
 #endif
-
-#include "caffe/layer.hpp"
-#include "caffe/vision_layers.hpp"
 
 namespace caffe {
 

--- a/src/caffe/layers/lrn_layer.cu
+++ b/src/caffe/layers/lrn_layer.cu
@@ -137,10 +137,13 @@ void LRNLayer<Dtype>::CrossChannelForward_gpu(
 #endif  // USE_GREENTEA
   }
 }
+
+#ifndef USE_GREENTEA
 template void LRNLayer<float>::CrossChannelForward_gpu(
     const vector<Blob<float>*>& bottom, const vector<Blob<float>*>& top);
 template void LRNLayer<double>::CrossChannelForward_gpu(
     const vector<Blob<double>*>& bottom, const vector<Blob<double>*>& top);
+#endif
 
 template<typename Dtype>
 void LRNLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
@@ -258,12 +261,15 @@ void LRNLayer<Dtype>::CrossChannelBackward_gpu(
 #endif  // USE_GREENTEA
   }
 }
+
+#if defined(USE_CUDA) || !defined(USE_GREENTEA)
 template void LRNLayer<float>::CrossChannelBackward_gpu(
     const vector<Blob<float>*>& top, const vector<bool>& propagate_down,
     const vector<Blob<float>*>& bottom);
 template void LRNLayer<double>::CrossChannelBackward_gpu(
     const vector<Blob<double>*>& top, const vector<bool>& propagate_down,
     const vector<Blob<double>*>& bottom);
+#endif
 
 INSTANTIATE_LAYER_GPU_FUNCS(LRNLayer);
 

--- a/src/caffe/layers/malis_loss_layer.cpp
+++ b/src/caffe/layers/malis_loss_layer.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <iterator>
 #include <map>
+#include <numeric>
 #include <queue>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
These commits contain changes necessary to build on OSX. I won't claim that they are 'correct' solutions to the problems I faced, but they should at least give pointers to what the problem is, and you can then come up with better fixes where appropriate.

Notes:
- I only worked with the CMake build.
- The 'runtest' target still does not build because TEST_DEVICE is not defined. I haven't looked in to this.
- I'm on OSX 10.9, using a hand-rolled clang 3.6.0. Haven't yet tested with the default clang that comes with XCode.
