### PR TITLE
Include CUDA only if using CUDA. Using OpenCL and CPU only didn't need include CUDA dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ endif
 CUDA_LIB_DIR += $(CUDA_DIR)/lib
 
 INCLUDE_DIRS += $(BUILD_INCLUDE_DIR) ./src ./include
-ifneq ($(CPU_ONLY), 1)
+ifeq ($(USE_CUDA), 1)
 	INCLUDE_DIRS += $(CUDA_INCLUDE_DIR)
 	LIBRARY_DIRS += $(CUDA_LIB_DIR)
 	LIBRARIES += cudart cublas curand


### PR DESCRIPTION
Include CUDA only if using CUDA. Using OpenCL and CPU only didn't need include  CUDA dependencies
