### PR TITLE
cmake/Cuda.cmake: properly spell '-std c++11' nvcc flag and do not repeat it twice in overlapping conditionals

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -145,11 +145,11 @@ macro(caffe_cuda_compile objlist_variable)
   endforeach()
 
   if(UNIX OR APPLE)
-    list(APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC -std=c++11)
+    list(APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC -std c++11)
   endif()
 
   if(APPLE)
-    list(APPEND CUDA_NVCC_FLAGS -std=c++11 -Xcompiler -Wno-unused-function)
+    list(APPEND CUDA_NVCC_FLAGS -Xcompiler -Wno-unused-function)
   endif()
 
   cuda_compile(cuda_objcs ${ARGN})


### PR DESCRIPTION
I can't test this locally because the build still fails in obscure toolchain internals (CUDA 7.5 / gcc 5.4), but at least nvcc does not complain about repeated `-std` flag.

Note that changing form of `-std=c++11` to `-std c++11` is crucial because FindCUDA.cmake machinery fails to check for the `-std=c++11` form in user-passed flags and hence appends its own flag, which chokes nvcc. (Who on Earth did decide to consider repeated flags as fatal errors?...)
