### PR TITLE
solver.cpp: do not include hdf5

### DIFF
--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -4,14 +4,10 @@
 #include <string>
 #include <vector>
 
-#include "hdf5.h"
-#include "hdf5_hl.h"
-
 #include "caffe/net.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/solver.hpp"
 #include "caffe/util/format.hpp"
-#include "caffe/util/hdf5.hpp"
 #include "caffe/util/io.hpp"
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/upgrade_proto.hpp"


### PR DESCRIPTION
These are redundant includes. I've stumbled upon these when building for Android without hdf5...
