### PR TITLE
Exclude HDF5-specific code when not supported

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -821,11 +821,15 @@ void Net<Dtype>::CopyTrainedLayersFrom(const NetParameter& param) {
 
 template<typename Dtype>
 void Net<Dtype>::CopyTrainedLayersFrom(const string trained_filename) {
+#ifdef USE_HDF5
   if (H5Fis_hdf5(trained_filename.c_str())) {
     CopyTrainedLayersFromHDF5(trained_filename);
   } else {
     CopyTrainedLayersFromBinaryProto(trained_filename);
   }
+#else
+  CopyTrainedLayersFromBinaryProto(trained_filename);
+#endif
 }
 
 template <typename Dtype>


### PR DESCRIPTION
This is to resolve issue #62 since HDF5 is not supported in Android builds.